### PR TITLE
fix: badges de workflow cassés dans le README (format d'URL déprécié)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Page de statut publique des services Kanta : **[status.kanta.fr](https://status.
 
 Le monitoring est propulsé par [Upptime](https://github.com/upptime/upptime) (checks toutes les 5 minutes via GitHub Actions). La page publique, elle, est une **page statique custom** maintenue dans [`site-custom/`](./site-custom) — pas l'UI Upptime par défaut.
 
-[![Uptime CI](https://github.com/Kanta-Inc/kanta-uptime/workflows/Uptime%20CI/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/uptime.yml)
-[![Response Time CI](https://github.com/Kanta-Inc/kanta-uptime/workflows/Response%20Time%20CI/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/response-time.yml)
-[![Graphs CI](https://github.com/Kanta-Inc/kanta-uptime/workflows/Graphs%20CI/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/graphs.yml)
-[![Static Site CI](https://github.com/Kanta-Inc/kanta-uptime/workflows/Static%20Site%20CI/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/site.yml)
-[![Summary CI](https://github.com/Kanta-Inc/kanta-uptime/workflows/Summary%20CI/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/summary.yml)
+[![Uptime CI](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/uptime.yml/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/uptime.yml)
+[![Response Time CI](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/response-time.yml/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/response-time.yml)
+[![Graphs CI](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/graphs.yml/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/graphs.yml)
+[![Static Site CI](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/site.yml/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/site.yml)
+[![Summary CI](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/summary.yml/badge.svg)](https://github.com/Kanta-Inc/kanta-uptime/actions/workflows/summary.yml)
 
 [**→ Voir la page de statut**](https://status.kanta.fr)
 


### PR DESCRIPTION
## Problème

Les 5 badges de workflow dans le header du README s'affichaient comme **images cassées**.

Cause : ils utilisaient l'ancien format d'URL GitHub déprécié
`github.com/Kanta-Inc/kanta-uptime/workflows/<Nom>/badge.svg`, qui ne renvoie
plus que des erreurs **502/503** ("Backend fetch failed" / "Unicorn!") — testé
plusieurs fois de suite, c'est systématique.

Les workflows eux-mêmes tournent et **réussissent** ; seule l'URL du badge était en cause.

## Correctif

Passage au format moderne `/actions/workflows/<fichier>.yml/badge.svg`, qui
répond **HTTP 200** de façon fiable pour les 5 badges (vérifié par `curl`).
Les liens cibles étaient déjà corrects et sont inchangés.

## Hors périmètre (pour info)

Les images du **tableau de statut** (vignettes de courbes `graphs/*.png` et
badges shields `api/*.json`) sont aussi cassées, mais c'est un **démarrage à
froid** suite à la mise à jour du template Upptime → v1.42.3 du 5 juin, qui a
renommé les monitors et remis l'historique à zéro. La chaîne (Response Time CI
→ Graphs CI) ré-enregistre 1 point/jour : `api/` et `graphs/` se reconstruiront
automatiquement, et le « uptime 30 jours » deviendra un vrai chiffre vers début
juillet. Aucune action requise côté code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)